### PR TITLE
Add Story components and node wrappers

### DIFF
--- a/pages/approved.tsx
+++ b/pages/approved.tsx
@@ -16,7 +16,7 @@ export default function Approved({ pages }: Props) {
       </h1>
 
       <div style={{ display: "grid", gap: "1rem" }}>
-        {pages.map(({ slug, updatedAt, ...res }) => (
+        {pages.map(({ slug, updatedAt }) => (
           <Link
             key={slug}
             href={`/review/${slug}`}

--- a/pages/edit/[[...slug]].tsx
+++ b/pages/edit/[[...slug]].tsx
@@ -1,8 +1,8 @@
 // pages/edit/[[...slug]].tsx
 import { Editor, Frame, Element, useEditor } from "@craftjs/core";
-import { RenderNode, Viewport } from "components/editor";
-import { ComponentsMap } from "components/registry/ComponentsMap";
-import { Container, Text } from "components/selectors";
+import { RenderNode, Viewport } from "@/components/editor";
+import { ComponentsMap } from "@/components/registry/ComponentsMap";
+import { Container, Text } from "@/components/selectors";
 import { GetServerSideProps } from "next";
 import { useEffect } from "react";
 

--- a/pages/review/[slug].tsx
+++ b/pages/review/[slug].tsx
@@ -4,8 +4,8 @@ import { useEffect, useState } from "react";
 import { Editor, Frame, Element } from "@craftjs/core";
 
 // 상태 복원용 renderer
-import { ComponentsMap } from "components/registry/ComponentsMap";
-import { CraftPreviewRenderer } from "components/review/CraftPreviewRenderer";
+import { ComponentsMap } from "@/components/registry/ComponentsMap";
+import { CraftPreviewRenderer } from "@/components/review/CraftPreviewRenderer";
 import Link from "next/link";
 
 export default function ReviewPage() {

--- a/src/components/node/components-map.tsx
+++ b/src/components/node/components-map.tsx
@@ -23,6 +23,8 @@ import {
 } from "../ui/article-title";
 import { NodeBenefitBgSection } from "./bg-section";
 import { NodeText } from "./Text";
+import { NodeStoryItem } from "./story-item";
+import { NodeStoryList } from "./story-list";
 
 export type Components = {
   name: string;
@@ -149,6 +151,19 @@ export const componentsMap: Components[] = [
         props: {},
       },
       { name: "Text", node: <NodeText /> },
+    ],
+  },
+  {
+    name: "Stories",
+    items: [
+      {
+        name: "StoryItem",
+        node: <NodeStoryItem imgSrc="/sample.jpg" title="Title" subTitle="Sub" linkUrl="/" />,
+      },
+      {
+        name: "StoryList",
+        node: <NodeStoryList id="story-list" />,
+      },
     ],
   },
 ];

--- a/src/components/node/story-item.tsx
+++ b/src/components/node/story-item.tsx
@@ -1,0 +1,14 @@
+import { withNode } from "./connector";
+import { SettingsControl } from "../settings-control";
+import { StoryItem } from "../ui/story-item";
+
+const draggable = true;
+
+export const NodeStoryItem = withNode(StoryItem, { draggable });
+
+NodeStoryItem.craft = {
+  ...NodeStoryItem.craft,
+  related: {
+    toolbar: SettingsControl,
+  },
+};

--- a/src/components/node/story-list.tsx
+++ b/src/components/node/story-list.tsx
@@ -1,0 +1,53 @@
+import { withNode } from "./connector";
+import { SettingsControl } from "../settings-control";
+import { StoryList } from "../ui/story-list";
+import { Element } from "@craftjs/core";
+import { NodeStoryItem } from "./story-item";
+
+const draggable = true;
+const droppable = true;
+
+export const NodeStoryListContainer = withNode(StoryList, {
+  draggable,
+  droppable,
+});
+
+export const NodeStoryList = (
+  props: React.ComponentProps<typeof StoryList>
+) => {
+  return (
+    <NodeStoryListContainer {...props}>
+      <Element
+        canvas
+        is={NodeStoryItem as typeof NodeStoryItem & string}
+        id="first"
+      />
+      <Element
+        canvas
+        is={NodeStoryItem as typeof NodeStoryItem & string}
+        id="second"
+      />
+      <Element
+        canvas
+        is={NodeStoryItem as typeof NodeStoryItem & string}
+        id="third"
+      />
+      <Element
+        canvas
+        is={NodeStoryItem as typeof NodeStoryItem & string}
+        id="fourth"
+      />
+    </NodeStoryListContainer>
+  );
+};
+
+NodeStoryList.craft = {
+  displayName: "StoryList",
+  props: {},
+  custom: {
+    importPath: "@/components/story-list",
+  },
+  related: {
+    toolbar: SettingsControl,
+  },
+};

--- a/src/components/ui/story-item.tsx
+++ b/src/components/ui/story-item.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { Route } from "next";
+import { cn } from "@/lib/utils";
+
+export interface StoryItemProps
+  extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  imgSrc?: string;
+  title?: string;
+  subTitle?: string;
+  linkUrl?: string;
+  bg?: string;
+}
+
+const StoryItem = React.forwardRef<HTMLAnchorElement, StoryItemProps>(
+  (
+    {
+      imgSrc = "",
+      title = "",
+      subTitle = "",
+      linkUrl = "#",
+      bg,
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <Link
+        href={linkUrl as Route}
+        ref={ref}
+        className={cn("flex w-full gap-12", className)}
+        {...props}
+      >
+        <div
+          className={cn(
+            "relative h-[93px] w-[140px] flex-shrink-0 rounded-8",
+            bg
+          )}
+        >
+          <Image
+            src={imgSrc}
+            alt={title}
+            fill
+            className="rounded-8 object-cover"
+          />
+        </div>
+        <div className="flex flex-col gap-12">
+          <h4 className="text-18 font-bold leading-normal text-[#2C2C2C]">
+            {title}
+          </h4>
+          <p className="text-14 font-medium leading-normal text-[#788093]">
+            {subTitle}
+          </p>
+        </div>
+      </Link>
+    );
+  }
+);
+StoryItem.displayName = "StoryItem";
+
+export { StoryItem };

--- a/src/components/ui/story-list.tsx
+++ b/src/components/ui/story-list.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+export interface StoryListProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  background?: string;
+}
+
+const StoryList = React.forwardRef<HTMLDivElement, StoryListProps>(
+  ({ background, className, children, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn("flex flex-col gap-20", className)}
+        style={{ background }}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+StoryList.displayName = "StoryList";
+
+export { StoryList };


### PR DESCRIPTION
## Summary
- add StoryItem and StoryList UI components
- add node wrappers for StoryItem and StoryList
- include new Story node components in components map
- fix TypeScript issues in pages

## Testing
- `npm install`
- `npm run build` *(fails: Duplicate function implementation in scripts/generateComponentsMap.ts)*


------
https://chatgpt.com/codex/tasks/task_e_683fa7f090bc832ea0f2f09cd5798496