### PR TITLE
Add node copy and paste

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
-
 import '../styles/app.css';
+import { ClipboardProvider } from '@/lib/clipboard';
 
 function MyApp({ Component, pageProps }) {
-  return <Component {...pageProps} />;
+  return (
+    <ClipboardProvider>
+      <Component {...pageProps} />
+    </ClipboardProvider>
+  );
 }
 
 // Only uncomment this method if you have blocking data requirements for

--- a/src/components/editor/RenderNode.tsx
+++ b/src/components/editor/RenderNode.tsx
@@ -10,6 +10,8 @@ import { styled } from "styled-components";
 import { LuMove } from "react-icons/lu";
 import { MdDeleteForever } from "react-icons/md";
 import { GoArrowUp } from "react-icons/go";
+import { FaCopy, FaPaste } from "react-icons/fa";
+import { useClipboard } from "@/lib/clipboard";
 
 const IndicatorDiv = styled.div`
   height: 30px;
@@ -61,6 +63,7 @@ export const RenderNode = ({ render }) => {
   }));
 
   const currentRef = React.useRef<HTMLDivElement | null>(null);
+  const { tree, setTree } = useClipboard();
 
   React.useEffect(() => {
     if (dom) {
@@ -137,6 +140,31 @@ export const RenderNode = ({ render }) => {
                   <GoArrowUp viewBox="-4 -1 24 24" />
                 </Btn>
               )}
+              <Btn
+                className="mr-2 cursor-pointer"
+                onMouseDown={(e: React.MouseEvent) => {
+                  e.stopPropagation();
+                  const t = query.node(id).toNodeTree();
+                  setTree(t);
+                }}
+              >
+                <FaCopy />
+              </Btn>
+              {tree ? (
+                <Btn
+                  className="mr-2 cursor-pointer"
+                  onMouseDown={(e: React.MouseEvent) => {
+                    e.stopPropagation();
+                    const parentId = query.node(id).get().data.parent;
+                    const index =
+                      query.node(parentId).childNodes().indexOf(id) + 1;
+                    actions.addNodeTree(tree, parentId, index);
+                    actions.selectNode(tree.rootNodeId);
+                  }}
+                >
+                  <FaPaste />
+                </Btn>
+              ) : null}
               {deletable ? (
                 <Btn
                   className="cursor-pointer"

--- a/src/components/editor/Viewport/index.tsx
+++ b/src/components/editor/Viewport/index.tsx
@@ -1,6 +1,7 @@
-import { useEditor } from "@craftjs/core";
+import { useEditor, ROOT_NODE } from "@craftjs/core";
 import cx from "classnames";
 import React, { useEffect } from "react";
+import { useClipboard } from "@/lib/clipboard";
 
 import { Header } from "./Header";
 import { Sidebar } from "./Sidebar";
@@ -12,10 +13,42 @@ export const Viewport: React.FC<{ children?: React.ReactNode }> = ({
   const {
     enabled,
     connectors,
-    actions: { setOptions },
-  } = useEditor((state) => ({
+    actions: { setOptions, addNodeTree, selectNode },
+    query,
+  } = useEditor((state, query) => ({
     enabled: state.options.enabled,
+    query,
   }));
+  const { tree, setTree } = useClipboard();
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (!enabled) return;
+      if ((e.metaKey || e.ctrlKey) && e.key === "c") {
+        const id = query.getEvent("selected").first();
+        if (id) {
+          e.preventDefault();
+          const t = query.node(id).toNodeTree();
+          setTree(t);
+        }
+      }
+      if ((e.metaKey || e.ctrlKey) && e.key === "v") {
+        if (!tree) return;
+        e.preventDefault();
+        const selected = query.getEvent("selected").first();
+        const parent = selected
+          ? query.node(selected).get().data.parent
+          : ROOT_NODE;
+        const index = selected
+          ? query.node(parent).childNodes().indexOf(selected) + 1
+          : undefined;
+        addNodeTree(tree, parent, index);
+        selectNode(tree.rootNodeId);
+      }
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [enabled, tree, query, addNodeTree, selectNode, setTree]);
 
   useEffect(() => {
     if (!window) {

--- a/src/lib/clipboard.tsx
+++ b/src/lib/clipboard.tsx
@@ -1,0 +1,24 @@
+import React, { createContext, useContext, useState } from "react";
+import { NodeTree } from "@craftjs/core";
+
+interface ClipboardState {
+  tree: NodeTree | null;
+  setTree: (tree: NodeTree | null) => void;
+}
+
+const ClipboardContext = createContext<ClipboardState | undefined>(undefined);
+
+export const ClipboardProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [tree, setTree] = useState<NodeTree | null>(null);
+  return (
+    <ClipboardContext.Provider value={{ tree, setTree }}>
+      {children}
+    </ClipboardContext.Provider>
+  );
+};
+
+export const useClipboard = () => {
+  const ctx = useContext(ClipboardContext);
+  if (!ctx) throw new Error("useClipboard must be used within ClipboardProvider");
+  return ctx;
+};


### PR DESCRIPTION
## Summary
- add clipboard context for storing copied nodes
- wrap app with `ClipboardProvider`
- add keyboard shortcuts for copying and pasting nodes
- show copy/paste icons on each node

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684161017ffc832e98eed53da8f93c81