### PR TITLE
Implement multi-select copy/paste

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,5 @@
 import { Editor, Frame, Element } from "@craftjs/core";
+import { DefaultEventHandlers } from "@craftjs/core";
 import { SideMenu } from "@/components/side-menu";
 import { Header } from "@/components/header";
 import { Canvas } from "@/components/canvas";
@@ -39,6 +40,7 @@ import { NodeStoryItem } from "@/components/node/story-item";
 import { NodeComparisonTable } from "@/components/node/comparison-table";
 import { NodeContainer } from "@/components/node/container";
 import { NodeImage } from "@/components/node/image";
+import { EditorHotkeys } from "@/components/editor-hotkeys";
 
 export default function Index() {
   return (
@@ -76,7 +78,15 @@ export default function Index() {
           NodeImage,
         }}
         onRender={RenderNode}
+        handlers={(store) =>
+          new DefaultEventHandlers({
+            store,
+            isMultiSelectEnabled: (e: MouseEvent) => e.shiftKey || e.metaKey,
+            removeHoverOnMouseleave: true,
+          })
+        }
       >
+        <EditorHotkeys />
         <div className="flex flex-1 relative overflow-hidden">
           <SideMenu componentsMap={componentsMap} />
           <Viewport>

--- a/src/components/editor-hotkeys.tsx
+++ b/src/components/editor-hotkeys.tsx
@@ -1,0 +1,44 @@
+import { useEditor } from "@craftjs/core";
+import { useEffect } from "react";
+
+export const EditorHotkeys = () => {
+  const { actions, query } = useEditor();
+
+  useEffect(() => {
+    const handleKeyDown = async (e: KeyboardEvent) => {
+      const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+      const isCopy = (isMac ? e.metaKey : e.ctrlKey) && e.key.toLowerCase() === "c";
+      const isPaste = (isMac ? e.metaKey : e.ctrlKey) && e.key.toLowerCase() === "v";
+
+      if (isCopy) {
+        const ids = query.getEvent("selected").all();
+        const serialized = ids.map((id) => query.node(id).toSerializedNode());
+        try {
+          await navigator.clipboard.writeText(JSON.stringify(serialized));
+        } catch (err) {
+          console.error("Copy failed", err);
+        }
+      }
+
+      if (isPaste) {
+        try {
+          const text = await navigator.clipboard.readText();
+          const data = JSON.parse(text);
+          if (Array.isArray(data)) {
+            data.forEach((sn: any) => {
+              const node = query.parseSerializedNode(sn).toNode();
+              actions.add(node, "ROOT");
+            });
+          }
+        } catch (err) {
+          console.error("Paste failed", err);
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [actions, query]);
+
+  return null;
+};


### PR DESCRIPTION
## Summary
- add editor keyboard listener for copy & paste
- enable multi-select in Editor using `DefaultEventHandlers`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68416bba0114832e87fe03dc445b71b9