### PR TITLE
Add copy/paste support

### DIFF
--- a/pages/edit/[[...slug]].tsx
+++ b/pages/edit/[[...slug]].tsx
@@ -1,6 +1,8 @@
 // pages/edit/[[...slug]].tsx
 import { Editor, Frame, Element, useEditor } from "@craftjs/core";
-import { RenderNode, Viewport } from "@/components/editor";
+import { Viewport } from "@/components/viewport";
+import { RenderNode } from "@/components/render-node";
+import { CopyPasteHelper } from "@/hooks/CopyPasteHelper";
 import { ComponentsMap } from "@/components/registry/ComponentsMap";
 import { Container, Text } from "@/components/selectors";
 import { GetServerSideProps } from "next";
@@ -40,6 +42,7 @@ export default function EditPage({ slug, json }: Props) {
           </>
         )}
       </Viewport>
+      <CopyPasteHelper />
     </Editor>
   );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -39,6 +39,7 @@ import { NodeStoryItem } from "@/components/node/story-item";
 import { NodeComparisonTable } from "@/components/node/comparison-table";
 import { NodeContainer } from "@/components/node/container";
 import { NodeImage } from "@/components/node/image";
+import { CopyPasteHelper } from "@/hooks/CopyPasteHelper";
 
 export default function Index() {
   return (
@@ -96,6 +97,7 @@ export default function Index() {
 
           <ControlPanel />
         </div>
+        <CopyPasteHelper />
       </Editor>
     </section>
   );

--- a/src/hooks/CopyPasteHelper.tsx
+++ b/src/hooks/CopyPasteHelper.tsx
@@ -1,0 +1,6 @@
+import { useCopyPaste } from "./useCopyPaste";
+
+export const CopyPasteHelper = () => {
+  useCopyPaste();
+  return null;
+};

--- a/src/hooks/useCopyPaste.ts
+++ b/src/hooks/useCopyPaste.ts
@@ -1,0 +1,61 @@
+import { useEditor } from "@craftjs/core";
+import { useEffect, useRef } from "react";
+
+import type { Node, NodeTree } from "@craftjs/core";
+
+// simple random id generator similar to nanoid
+const generateId = () => Math.random().toString(36).substr(2, 9);
+
+function cloneTree(tree: NodeTree): NodeTree {
+  const idMap: Record<string, string> = {};
+  Object.keys(tree.nodes).forEach((id) => {
+    idMap[id] = generateId();
+  });
+  const newNodes: Record<string, Node> = {};
+  Object.entries(tree.nodes).forEach(([oldId, node]) => {
+    const newId = idMap[oldId];
+    newNodes[newId] = {
+      ...node,
+      id: newId,
+      data: {
+        ...node.data,
+        parent: node.data.parent ? idMap[node.data.parent] || node.data.parent : null,
+        nodes: node.data.nodes.map((child) => idMap[child]),
+        linkedNodes: Object.fromEntries(
+          Object.entries(node.data.linkedNodes || {}).map(([key, val]) => [key, idMap[val]])
+        ),
+      },
+    };
+  });
+  return { rootNodeId: idMap[tree.rootNodeId], nodes: newNodes };
+}
+
+export const useCopyPaste = () => {
+  const { query, actions } = useEditor();
+  const clipboard = useRef<NodeTree | null>(null);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "c") {
+        e.preventDefault();
+        const id = query.getEvent("selected").first();
+        if (id) {
+          clipboard.current = query.node(id).toNodeTree();
+        }
+      }
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "v") {
+        if (!clipboard.current) return;
+        e.preventDefault();
+        const target = query.getEvent("selected").first();
+        if (!target) return;
+        const parentId = query.node(target).get().data.parent as string;
+        const parentNode = query.node(parentId).get();
+        const index = parentNode.data.nodes.indexOf(target) + 1;
+        const cloned = cloneTree(clipboard.current);
+        actions.addNodeTree(cloned, parentId, index);
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [query, actions]);
+};


### PR DESCRIPTION
## Summary
- add hook for copy & paste
- enable keyboard shortcuts in editor pages

## Testing
- `npm install`
- `npm run build` *(fails: Cannot find module '@/components/registry/ComponentsMap')*

------
https://chatgpt.com/codex/tasks/task_e_684162fe97a0832eb52398b4c2ff1eb5