### PR TITLE
Fix copy-paste and selection

### DIFF
--- a/src/components/render-node.tsx
+++ b/src/components/render-node.tsx
@@ -40,5 +40,11 @@ export const RenderNode = ({ render }: { render: React.ReactNode }) => {
     }
   }, [dom, isHover]);
 
+  useEffect(() => {
+    if (dom && id !== "ROOT") {
+      dom.classList.toggle("component-selected", isSelected);
+    }
+  }, [dom, isSelected]);
+
   return <>{render}</>;
 };

--- a/src/hooks/useCopyPaste.ts
+++ b/src/hooks/useCopyPaste.ts
@@ -56,6 +56,13 @@ export const useCopyPaste = () => {
       }
     };
     document.addEventListener("keydown", handler);
-    return () => document.removeEventListener("keydown", handler);
+    const iframe = document.getElementById("canvas-iframe") as HTMLIFrameElement | null;
+    const iframeDoc = iframe?.contentWindow?.document;
+    iframeDoc?.addEventListener("keydown", handler);
+
+    return () => {
+      document.removeEventListener("keydown", handler);
+      iframeDoc?.removeEventListener("keydown", handler);
+    };
   }, [query, actions]);
 };


### PR DESCRIPTION
## Summary
- support key events in iframe so pasted nodes render
- highlight all selected nodes correctly

## Testing
- `npm run build` *(fails: cannot find module '@/components/registry/ComponentsMap')*

------
https://chatgpt.com/codex/tasks/task_e_684177122550832eb0dce18c22136cdd