### PR TITLE
Fix pasted nodes remaining selected

### DIFF
--- a/src/hooks/useCopyPaste.ts
+++ b/src/hooks/useCopyPaste.ts
@@ -17,6 +17,7 @@ function cloneTree(tree: NodeTree): NodeTree {
     newNodes[newId] = {
       ...node,
       id: newId,
+      events: { selected: false, hovered: false, dragged: false },
       data: {
         ...node.data,
         parent: node.data.parent ? idMap[node.data.parent] || node.data.parent : null,


### PR DESCRIPTION
## Summary
- reset selection events when cloning nodes during paste

## Testing
- `npm run build` *(fails: Cannot find module '@/components/registry/ComponentsMap' during compilation)*

------
https://chatgpt.com/codex/tasks/task_e_6841a2ab7728832e8af94e8b50306b7b