### PR TITLE
Fix CodeView publish

### DIFF
--- a/pages/api/publish.ts
+++ b/pages/api/publish.ts
@@ -41,13 +41,18 @@ export default async function handler(
 
     const baseSha = baseRef.object.sha;
 
-    // 2. Create a new branch from main
-    await octokit.rest.git.createRef({
-      owner: REPO_OWNER,
-      repo: REPO_NAME,
-      ref: `refs/heads/${branchName}`,
-      sha: baseSha,
-    });
+    // 2. Create a new branch from main if it doesn't already exist
+    try {
+      await octokit.rest.git.createRef({
+        owner: REPO_OWNER,
+        repo: REPO_NAME,
+        ref: `refs/heads/${branchName}`,
+        sha: baseSha,
+      });
+    } catch (err: any) {
+      // Branch already exists
+      if (err.status !== 422) throw err;
+    }
 
     // 3. Create or update file in the new branch
     await octokit.rest.repos.createOrUpdateFileContents({

--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -41,10 +41,11 @@ export const CodeView = ({ codeString }: { codeString?: string }) => {
     }
 
     try {
+      const serialized = query.serialize();
       const res = await fetch("/api/publish", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ slug, data: query.getNodes() }),
+        body: JSON.stringify({ slug, data: serialized }),
       });
       const json = await res.json();
       if (res.ok) {


### PR DESCRIPTION
## Summary
- fix CodeView serialization when sending data to publish API
- allow publish API to skip branch creation if branch already exists

## Testing
- `npm run build` *(fails: Cannot find module '@/components/registry/ComponentsMap')*

------
https://chatgpt.com/codex/tasks/task_e_6841abf83064832e8696241c4ac844d5