### PR TITLE
Enable editing merged pages

### DIFF
--- a/pages/approved/[slug].tsx
+++ b/pages/approved/[slug].tsx
@@ -1,0 +1,159 @@
+import { Editor, Frame, Element, DefaultEventHandlers, useEditor } from "@craftjs/core";
+import { SideMenu } from "@/components/side-menu";
+import { Header } from "@/components/header";
+import { Canvas } from "@/components/canvas";
+import { ReactIframe } from "@/components/react-iframe";
+import { ControlPanel } from "@/components/control-panel";
+import { Viewport } from "@/components/viewport";
+import { RenderNode } from "@/components/render-node";
+import { componentsMap } from "@/components/node/components-map";
+import { NodeButton } from "@/components/node/button";
+import {
+  NodeCardHeader,
+  NodeCard,
+  NodeCardContent,
+  NodeCardDescription,
+  NodeCardTitle,
+  NodeCardFooter,
+} from "@/components/node/card";
+import { NodeOneBlock, NodeTwoBlocks } from "@/components/node/layout";
+import {
+  NodeArticleTitle,
+  NodeArticleTitleContainer,
+  NodeArticleTitleDivider,
+  NodeArticleTitleHeader,
+  NodeArticleTitleMain,
+  NodeArticleTitleSub,
+  NodeArticleTitleText,
+} from "@/components/node/article-title";
+import {
+  NodeBenefitBgSection,
+  NodeBenefitBgSectionContainer,
+  NodeBenefitBgSectionItem,
+  NodeBenefitBgSectionTitle,
+  NodeBgSectionContent,
+} from "@/components/node/bg-section";
+import { NodeText } from "@/components/node/Text";
+import { NodeStoryList } from "@/components/node/story-list";
+import { NodeStoryItem } from "@/components/node/story-item";
+import { NodeComparisonTable } from "@/components/node/comparison-table";
+import { NodeContainer } from "@/components/node/container";
+import { NodeImage } from "@/components/node/image";
+import {
+  NodeImportantTitle,
+  NodeImportantTitleContainer,
+  NodeImportantTitleText,
+} from "@/components/node/important-title";
+import { CopyPasteHelper } from "@/hooks/CopyPasteHelper";
+import { GetServerSideProps } from "next";
+import { useEffect } from "react";
+
+interface Props {
+  slug: string;
+  json: string;
+}
+
+export default function EditApprovedPage({ slug, json }: Props) {
+  return (
+    <section className="w-full min-h-screen flex flex-col">
+      <Header />
+      <Editor
+        resolver={{
+          NodeButton,
+          Canvas,
+          NodeCardHeader,
+          NodeCard,
+          NodeCardContent,
+          NodeCardDescription,
+          NodeCardTitle,
+          NodeCardFooter,
+          NodeOneBlock,
+          NodeTwoBlocks,
+          NodeArticleTitle,
+          NodeArticleTitleContainer,
+          NodeArticleTitleDivider,
+          NodeArticleTitleHeader,
+          NodeArticleTitleMain,
+          NodeArticleTitleSub,
+          NodeArticleTitleText,
+          NodeBenefitBgSectionContainer,
+          NodeBenefitBgSectionItem,
+          NodeBenefitBgSection,
+          NodeBenefitBgSectionTitle,
+          NodeBgSectionContent,
+          NodeText,
+          NodeStoryList,
+          NodeStoryItem,
+          NodeComparisonTable,
+          NodeContainer,
+          NodeImage,
+          NodeImportantTitle,
+          NodeImportantTitleText,
+          NodeImportantTitleContainer,
+        }}
+        onRender={RenderNode}
+        handlers={(store) =>
+          new DefaultEventHandlers({
+            store,
+            isMultiSelectEnabled: (e: MouseEvent) => e.shiftKey || e.metaKey,
+            removeHoverOnMouseleave: true,
+          })
+        }
+      >
+        <div className="flex flex-1 relative overflow-hidden">
+          <SideMenu componentsMap={componentsMap} />
+          <Viewport>
+            <ReactIframe title="page" className="p-64 w-full h-full page-container">
+              <EditorInitializer slug={slug} json={json} />
+              <Frame>
+                <Element is={Canvas} id="ROOT" canvas>
+                  {null}
+                </Element>
+              </Frame>
+            </ReactIframe>
+          </Viewport>
+          <ControlPanel />
+        </div>
+        <CopyPasteHelper />
+      </Editor>
+    </section>
+  );
+}
+
+function EditorInitializer({ slug, json }: { slug: string; json: string }) {
+  const { actions } = useEditor();
+
+  useEffect(() => {
+    try {
+      actions.deserialize(JSON.parse(json));
+    } catch (err) {
+      console.error("deserialize 실패:", err);
+    }
+  }, [slug, json]);
+
+  return null;
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
+  const slug = ctx.params?.slug;
+  if (typeof slug !== "string") return { notFound: true };
+
+  const res = await fetch(
+    `https://raw.githubusercontent.com/OhSeungWan/rentre-fae-data/main/data/${slug}.json`,
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+      },
+    }
+  );
+
+  if (!res.ok) {
+    return { notFound: true };
+  }
+
+  const text = await res.text();
+
+  return {
+    props: { slug, json: text },
+  };
+};

--- a/pages/approved/index.tsx
+++ b/pages/approved/index.tsx
@@ -19,7 +19,7 @@ export default function Approved({ pages }: Props) {
         {pages.map(({ slug, updatedAt }) => (
           <Link
             key={slug}
-            href={`/review/${slug}`}
+            href={`/approved/${slug}`}
             style={{
               display: "block",
               padding: "1rem",
@@ -66,13 +66,13 @@ export const getServerSideProps: GetServerSideProps<Props> = async () => {
 
     const status = file?.ROOT?.custom?.status;
     const updatedAt = file?.ROOT?.custom?.updatedAt;
-    console.log(file);
-    // if (status === "approved") {
-    // }
-    pages.push({
-      slug: item.name.replace(".json", ""),
-      updatedAt: updatedAt ?? new Date().toISOString(),
-    });
+
+    if (status === "approved") {
+      pages.push({
+        slug: item.name.replace(".json", ""),
+        updatedAt: updatedAt ?? new Date().toISOString(),
+      });
+    }
   }
 
   // const pages = raw

--- a/pages/edit/[[...slug]].tsx
+++ b/pages/edit/[[...slug]].tsx
@@ -4,7 +4,8 @@ import { Viewport } from "@/components/viewport";
 import { RenderNode } from "@/components/render-node";
 import { CopyPasteHelper } from "@/hooks/CopyPasteHelper";
 import { ComponentsMap } from "@/components/registry/ComponentsMap";
-import { Container, Text } from "@/components/selectors";
+import { NodeContainer } from "@/components/node/container";
+import { NodeText } from "@/components/node/Text";
 import { GetServerSideProps } from "next";
 import { useEffect } from "react";
 
@@ -24,15 +25,10 @@ export default function EditPage({ slug, json }: Props) {
           <Frame>
             <Element
               canvas
-              is={Container}
-              width="600px"
-              height="auto"
-              background={{ r: 255, g: 255, b: 255, a: 1 }}
-              padding={["0", "0", "0", "0"]}
-              alignItems="center"
+              is={NodeContainer as typeof NodeContainer & string}
               custom={{ displayName: "App" }}
             >
-              <Text text="새 페이지를 시작해보세요!" />
+              <NodeText text="새 페이지를 시작해보세요!" />
             </Element>
           </Frame>
         ) : (

--- a/src/hooks/useCopyPaste.ts
+++ b/src/hooks/useCopyPaste.ts
@@ -22,8 +22,12 @@ function cloneTree(tree: NodeTree): NodeTree {
         ...node.data,
         parent: node.data.parent ? idMap[node.data.parent] || node.data.parent : null,
         nodes: node.data.nodes.map((child) => idMap[child]),
-        linkedNodes: Object.fromEntries(
-          Object.entries(node.data.linkedNodes || {}).map(([key, val]) => [key, idMap[val]])
+        linkedNodes: Object.entries(node.data.linkedNodes || {}).reduce(
+          (acc, [key, val]) => {
+            acc[key] = idMap[val];
+            return acc;
+          },
+          {} as Record<string, string>
         ),
       },
     };
@@ -50,7 +54,7 @@ export const useCopyPaste = () => {
         const target = query.getEvent("selected").first();
         if (!target) return;
 
-        let targetNode: ReturnType<typeof query.node> | null = null;
+        let targetNode: any = null;
         try {
           targetNode = query.node(target).get();
         } catch (err) {
@@ -59,7 +63,7 @@ export const useCopyPaste = () => {
         if (!targetNode) return;
 
         const parentId = targetNode.data.parent as string;
-        let parentNode: ReturnType<typeof query.node> | null = null;
+        let parentNode: any = null;
         try {
           parentNode = query.node(parentId).get();
         } catch (err) {

--- a/src/lib/code-gen.tsx
+++ b/src/lib/code-gen.tsx
@@ -48,7 +48,7 @@ const generateComponentCode = (
       : '';
 
     const linkedChildComponents = Object.entries(linkedNodes).map(([, value]) =>
-      generateComponentCode(nodesMap, value, level + 1)
+      generateComponentCode(nodesMap, value as string, level + 1)
     );
 
     const linkedChildComponentsString = linkedChildComponents.length


### PR DESCRIPTION
## Summary
- move approved list to folder and link each entry to an editor
- implement `/approved/[slug]` page that loads merged JSON into the full editor
- fix copy/paste helper compatibility with older TypeScript target
- adjust code generation typing
- fix dynamic edit page imports

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841b45246f0832e817b4192fc1650ab