### PR TITLE
Fix paste in text node

### DIFF
--- a/src/components/node/Text.tsx
+++ b/src/components/node/Text.tsx
@@ -54,6 +54,24 @@ export const NodeText = ({
           setLocalText(e.target.value);
         }, 500);
       }} // use true to disable editing
+      onPaste={(e) => {
+        e.preventDefault();
+        const text = e.clipboardData.getData("text/plain");
+        if (document.queryCommandSupported("insertText")) {
+          document.execCommand("insertText", false, text);
+        } else {
+          const selection = window.getSelection();
+          if (selection && selection.rangeCount > 0) {
+            selection.deleteFromDocument();
+            selection.getRangeAt(0).insertNode(document.createTextNode(text));
+          }
+        }
+        const current = contentRef.current?.innerText ?? text;
+        setProp((prop) => {
+          prop.text = current;
+          setLocalText(current);
+        }, 500);
+      }}
       tagName={tagName} // Use a custom HTML tag (uses a div by default)
       {...props}
     />


### PR DESCRIPTION
## Summary
- sanitize pasted text in `NodeText` component

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684658500088832e89a64391d4ffcf0d