### PR TITLE
Add local draft storage

### DIFF
--- a/pages/approved/[slug].tsx
+++ b/pages/approved/[slug].tsx
@@ -45,6 +45,7 @@ import {
   NodeImportantTitleText,
 } from "@/components/node/important-title";
 import { CopyPasteHelper } from "@/hooks/CopyPasteHelper";
+import { DraftStorageHelper } from "@/hooks/DraftStorageHelper";
 import { GetServerSideProps } from "next";
 import { parseTsx } from "@/lib/parseTsx";
 import { useEffect } from "react";
@@ -116,6 +117,7 @@ export default function EditApprovedPage({ slug, json }: Props) {
           <ControlPanel />
         </div>
         <CopyPasteHelper />
+        <DraftStorageHelper storageKey={`approved-${slug}`} />
       </Editor>
     </section>
   );

--- a/pages/edit/[[...slug]].tsx
+++ b/pages/edit/[[...slug]].tsx
@@ -3,6 +3,7 @@ import { Editor, Frame, Element, useEditor } from "@craftjs/core";
 import { Viewport } from "@/components/viewport";
 import { RenderNode } from "@/components/render-node";
 import { CopyPasteHelper } from "@/hooks/CopyPasteHelper";
+import { DraftStorageHelper } from "@/hooks/DraftStorageHelper";
 import { ComponentsMap } from "@/components/registry/ComponentsMap";
 import { NodeContainer } from "@/components/node/container";
 import { NodeText } from "@/components/node/Text";
@@ -40,6 +41,7 @@ export default function EditPage({ slug, json }: Props) {
         )}
       </Viewport>
       <CopyPasteHelper />
+      <DraftStorageHelper storageKey={`edit-${slug || 'new'}`} />
     </Editor>
   );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -33,6 +33,7 @@ import { NodeContainer } from "@/components/node/container";
 import { NodeImage } from "@/components/node/image";
 
 import { CopyPasteHelper } from "@/hooks/CopyPasteHelper";
+import { DraftStorageHelper } from "@/hooks/DraftStorageHelper";
 
 import {
   NodeImportantTitle,
@@ -101,6 +102,7 @@ export default function Index() {
           <ControlPanel />
         </div>
         <CopyPasteHelper />
+        <DraftStorageHelper />
       </Editor>
     </section>
   );

--- a/src/hooks/DraftStorageHelper.tsx
+++ b/src/hooks/DraftStorageHelper.tsx
@@ -1,0 +1,6 @@
+import { useDraftStorage } from "./useDraftStorage";
+
+export const DraftStorageHelper = ({ storageKey }: { storageKey?: string }) => {
+  useDraftStorage(storageKey);
+  return null;
+};

--- a/src/hooks/useDraftStorage.ts
+++ b/src/hooks/useDraftStorage.ts
@@ -1,0 +1,34 @@
+import { useEditor } from "@craftjs/core";
+import { useEffect, useRef } from "react";
+
+export const useDraftStorage = (key: string = "craft-draft") => {
+  const { query, actions } = useEditor();
+  const lastRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(key);
+      if (stored) {
+        actions.deserialize(JSON.parse(stored));
+        lastRef.current = stored;
+      }
+    } catch (err) {
+      console.error("Failed to load draft", err);
+    }
+  }, [key, actions]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      try {
+        const serialized = query.serialize();
+        if (serialized !== lastRef.current) {
+          localStorage.setItem(key, serialized);
+          lastRef.current = serialized;
+        }
+      } catch (err) {
+        console.error("Failed to save draft", err);
+      }
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [key, query]);
+};


### PR DESCRIPTION
## Summary
- add `useDraftStorage` hook and helper component
- persist editor data to localStorage for drafting
- include the draft helper in edit and approved pages

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684659401640832e890770f89276c333