### PR TITLE
Add header navigation bar

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -4,11 +4,19 @@ import Link from "next/link";
 
 export const Header = () => {
   return (
-    <nav className="flex items-center justify-between p-16 w-full border-b">
+    <nav className="flex items-center justify-between p-16 w-full border-b bg-white">
       <Link href="/" className="flex items-center space-x-8">
         <Command className="h-32 w-32" />
         <h2 className="text-xl font-semibold">Rentre-Fae</h2>
       </Link>
+      <div className="flex items-center space-x-32 text-sm font-medium">
+        <Link href="/edit" className="hover:underline">
+          편집
+        </Link>
+        <Link href="/approved" className="hover:underline">
+          승인 목록
+        </Link>
+      </div>
     </nav>
   );
 };


### PR DESCRIPTION
## Summary
- add a simple navigation bar to the header with links for 편집 and 승인 목록

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68495325d16c832e899f63856a49a70a